### PR TITLE
Implement AddToTagList() to store tags data in KV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: storage_server service chirp
 chirp: storage.pb.o storage.grpc.pb.o service.pb.o service.grpc.pb.o service.o storage_client.o storage_server.o cmd.o cmd_main.o thread_safe_map.o
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-service: storage.pb.o storage.grpc.pb.o service.pb.o service.grpc.pb.o storage_client.o service.o service_main.o thread_safe_map.o
+service: storage.pb.o storage.grpc.pb.o service.pb.o service.grpc.pb.o service_data.pb.o storage_client.o service.o service_main.o thread_safe_map.o
 	$(CXX) $^ $(LDFLAGS) -o $@
 
 storage_client: storage.pb.o storage.grpc.pb.o storage_client.o thread_safe_map.o storage_client_main.o
@@ -38,7 +38,7 @@ storage_server: storage.pb.o storage.grpc.pb.o storage_server.o thread_safe_map.
 storage_test: storage.pb.o storage.grpc.pb.o storage_test.o storage_client.o storage_server.o thread_safe_map.o 
 	$(CXX) $^ $(LDFLAGS) $(TESTFLAGS) -o $@
 
-service_test: storage.pb.o storage.grpc.pb.o service.pb.o service.grpc.pb.o storage_client.o storage_server.o thread_safe_map.o service.o cmd.o service_test.o 
+service_test: storage.pb.o storage.grpc.pb.o service.pb.o service.grpc.pb.o service_data.pb.o storage_client.o storage_server.o thread_safe_map.o service.o cmd.o service_test.o
 	$(CXX) $^ $(LDFLAGS) $(TESTFLAGS) -o $@
 
 .PRECIOUS: %.grpc.pb.cc

--- a/service.h
+++ b/service.h
@@ -110,13 +110,6 @@ class ServiceImpl final : public ServiceLayer::Service {
   // parse a list of usernames to individual usernames
   std::vector<std::string> parseUserList(const std::string& userlist);
 
- public:
-  // Make these member functions public for testing purpose
-  // get the storage client for testing purpose
-  inline StorageClient* const get_storage_client() {
-    return &(this->storageclient_);
-  }
-  //
   // add a new chirp id to a specific tag list
   // here I used tag name and chirps' time as they key to store in the KV-store
   void AddToTagList(const std::string& tag, const Timestamp& time,

--- a/service.h
+++ b/service.h
@@ -10,6 +10,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 #include "service.grpc.pb.h"
+#include "service_data.pb.h"
 #include "storage_client.h"
 
 using grpc::Server;
@@ -87,6 +88,7 @@ class ServiceImpl final : public ServiceLayer::Service {
   static const std::string kChirpEntryKeyPrefix;
   static const std::string kChirpReplyEntryKeyPrefix;
   static const std::string kUserChirpEntryKeyPrefix;
+  static const std::string kTagListKeyPrefix;
   static const int kPullingIntervalSeconds;
   // if this object is for testing
   bool testing_ = false;
@@ -107,6 +109,18 @@ class ServiceImpl final : public ServiceLayer::Service {
   std::vector<std::string> parseChirpList(const std::string& childrenlist);
   // parse a list of usernames to individual usernames
   std::vector<std::string> parseUserList(const std::string& userlist);
+
+ public:
+  // Make these member functions public for testing purpose
+  // get the storage client for testing purpose
+  inline StorageClient* const get_storage_client() {
+    return &(this->storageclient_);
+  }
+  //
+  // add a new chirp id to a specific tag list
+  // here I used tag name and chirps' time as they key to store in the KV-store
+  void AddToTagList(const std::string& tag, const Timestamp& time,
+                    const std::string& chirp_id);
 };
 
 #endif  // CHIRP_SERVICE_H_

--- a/service_data.proto
+++ b/service_data.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package ServiceData;
+
+message TagList {
+  repeated bytes chirp_ids = 1;
+}

--- a/service_test.cpp
+++ b/service_test.cpp
@@ -300,62 +300,10 @@ class ServiceTagTest : public ::testing::Test {
   void SetUp() override {
     // get the pointers of service and its storage client
     service_.reset(new ServiceImpl(true));
-    storageclient_ = service_->get_storage_client();
-
-    // set up test contents
-    Timestamp time;
-    time.set_seconds(1000);
-    for (size_t i = 0; i < kTestCase; ++i) {
-      times.push_back(time);
-
-      time.set_seconds(time.seconds() + 30);
-    }
   }
 
   std::unique_ptr<ServiceImpl> service_;
-  StorageClient* storageclient_;
-
-  const size_t kTestCase = 10;
-  const std::string kKeyPrefix = "TAGLIST_";
-  std::vector<Timestamp> times;
-  std::vector<std::string> tags_ = {"tag1", "tag2"};
 };
-
-TEST_F(ServiceTagTest, AddToTagList) {
-  // store all correct data
-  // map from KV-store's key to its vector storing chirp ids
-  std::map<std::string, std::vector<std::string> > map;
-
-  // call the tested function and store correct data
-  for (size_t i = 0; i < kTestCase; ++i) {
-    const std::string& tag = tags_[i % 2];
-    const std::string chirp_id = std::to_string(i);
-
-    service_->AddToTagList(tag, times[i], chirp_id);
-
-    // store the correct data in the map in this testing
-    std::string time_str = std::to_string(times[i].seconds() / 100);
-    time_str.insert(0, 10 - time_str.size(), '0');
-    map[kKeyPrefix + time_str + tag].push_back(chirp_id);
-  }
-
-  // read from KV-store
-  for (const auto& it : map) {
-    // make the data are stored in KV-store
-    EXPECT_TRUE(storageclient_->has(it.first));
-
-    // get the data stored in KV-store and deserialize them
-    std::string data_from_kv = storageclient_->get(it.first);
-    ServiceData::TagList tag_list;
-    tag_list.ParseFromString(data_from_kv);
-
-    // check if the data from KV-store are equal to the data we store
-    ASSERT_EQ(tag_list.chirp_ids_size(), it.second.size());
-    for (int i = 0; i < tag_list.chirp_ids_size(); ++i) {
-      ASSERT_EQ(tag_list.chirp_ids(i), it.second[i]);
-    }
-  }
-}
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Given a tag name, a posting timestamp, and a chirp id, ```AddToTagList()``` stores tags data into KV-store for further uses.